### PR TITLE
header should be returned instead of remoteUser

### DIFF
--- a/support/cas-server-support-trusted/src/main/java/org/apereo/cas/adaptors/trusted/web/flow/PrincipalFromRequestHeaderNonInteractiveCredentialsAction.java
+++ b/support/cas-server-support-trusted/src/main/java/org/apereo/cas/adaptors/trusted/web/flow/PrincipalFromRequestHeaderNonInteractiveCredentialsAction.java
@@ -57,7 +57,7 @@ public class PrincipalFromRequestHeaderNonInteractiveCredentialsAction extends B
             if (headers.containsKey(this.remotePrincipalHeader)) {
                 final String header = headers.get(this.remotePrincipalHeader).get(0);
                 LOGGER.debug("Remote user [{}] found in [{}] header", header, this.remotePrincipalHeader);
-                return remoteUser;
+                return header;
             }
         }
         LOGGER.debug("No remote user [{}] could be found", remoteUser);


### PR DESCRIPTION
We have an auth mechanism at the apache layer that takes care of authentication. We are looking to use the following trusted authentication handler config. 

cas.authn.trusted.remotePrincipalHeader=OOO_REMOTE_USER

When kicking up the debug logs we can see that the username or credential is not being extracted from the header properly. Trusted auth works fine after making this code change, recompiling, and redeploying. 

Here is some further detail that was posted on the mailing list.

https://groups.google.com/a/apereo.org/forum/?utm_medium=email&utm_source=footer#!msg/cas-user/eW0fO9kxgGM/nJSVjrSBAgAJ

Thanks,
Majeed